### PR TITLE
Add method to get vehicle images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmw-connected-drive",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "This package can be used to access the BMW ConnectedDrive services.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm i -S bmw-connected-drive
 ## Usage
 
 ```javascript
-import { ConnectedDrive, Regions } from 'bmw-connected-drive';
+import { ConnectedDrive, CarBrand, Regions } from 'bmw-connected-drive';
 
 // Setup the API client
 const api = new ConnectedDrive(username, password, Regions.RestOfWorld);
@@ -20,10 +20,10 @@ const api = new ConnectedDrive(username, password, Regions.RestOfWorld);
 const vehicles = await api.getVehicles();
 
 // Trigger the Remote Service for remotely heating/cooling the car.
-await api.startClimateControl(vehicleIdentificationNumber);
+await api.startClimateControl(vehicleIdentificationNumber, CarBrand.Bmw);
 
 // Trigger the stopping Remote Service for remotely heating/cooling the car.
-await api.stopClimateControl(vehicleIdentificationNumber);
+await api.stopClimateControl(vehicleIdentificationNumber, CarBrand.Bmw);
 
 ```
 

--- a/src/CarView.ts
+++ b/src/CarView.ts
@@ -1,0 +1,11 @@
+export enum CarView {
+    Dashboard = "DASHBOARD",
+    DriverDoor = "DRIVERDOOR",
+    FrontLeft = "FRONTLEFT",
+    FrontRight = "FRONTRIGHT",
+    FrontView = "FRONTVIEW",
+    RearLeft = "REARLEFT",
+    RearRight = "REARRIGHT",
+    RearView = "REARVIEW",
+    SideViewLeft = "SIDEVIEWLEFT"
+}

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -36,6 +36,7 @@ export class Constants {
     static readonly executeRemoteServices: string =  Constants.remoteServicesBaseUrl + "/{vehicleVin}/{serviceType}";
     static readonly statusRemoteServices: string = Constants.remoteServicesBaseUrl + "/eventStatus?eventId={eventId}";
     static readonly statusRemoteServicePostion: string = Constants.remoteServicesBaseUrl + "/eventPosition?eventId={eventId}";
+    static readonly getImages: string = "/eadrax-ics/v5/presentation/vehicles/images?carView={carView}&toCrop=true";
 
     static readonly vehicleChargingDetailsUrl = "/eadrax-crccs/v2/vehicles";
     static readonly vehicleChargingBaseUrl = "/eadrax-crccs/v1/vehicles/{vehicleVin}";


### PR DESCRIPTION
A method `getImage` is added to get images of a vehicle. The CarView enum parameter is used to specify the different types of perspective views of the vehicle.

For example, this is what the `FrontView` image returns for the Mini Cooper SE:
 
![FrontView](https://github.com/lsiddiquee/bmw-connected-drive/assets/10097564/b303737d-5d9c-4b89-8390-ce1a929ab624)

Next to this functional change, a couple of other things were changed:
- The waitExecution parameter for executing a service didn't actually wait until the execution was finished. This is fixed now.
- The readme wasn't updated with the CarBrand parameter. That has been fixed too.